### PR TITLE
Declaring styleName variable before initializing in if_else block in chooseLabel()

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -81,6 +81,7 @@ function changeMode(widget, event) {
 
 function chooseLabel() {
 	addArg = (mode==4) ? true : false
+    var styleName;
     if (mode == 0 || mode == 1 || mode == 4) styleName =  'sumall'; 
     else if(!isVertical) styleName = 'upanddown';
     let extraw = '';


### PR DESCRIPTION
styleName is being initialized in the if_else block which makes it local to the if_else block but used by the following code. This results in the extension loading error (**JS ERROR: Extension netspeedsimplified@prateekmedia.extension: ReferenceError: styleName is not defined**).  styleName variable is declared before if_else block to solve this issue.