### PR TITLE
Adopted Make build system and added quick install method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+EXT_HOME=~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension
+
+all: install
+
+install: convenience.js extension.js metadata.json prefs.js stylesheet.css schemas/gschemas.compiled
+	#Create directory structure
+	mkdir -p ${EXT_HOME}
+	mkdir -p ${EXT_HOME}/schemas
+
+	#Copy compulsory files
+	cp convenience.js extension.js metadata.json prefs.js stylesheet.css ${EXT_HOME}
+	cp schemas/gschemas.compiled ${EXT_HOME}/schemas
+
+	#Optional files
+	cp LICENSE ${EXT_HOME} 2>/dev/null || true
+	cp README.md ${EXT_HOME} 2>/dev/null || true
+	cp screenshoot.png ${EXT_HOME} 2>/dev/null || true
+	cp schemas/org.gnome.shell.extensions.netspeedsimplified.gschema.xml ${EXT_HOME}/schemas 2>/dev/null || true
+
+	#Reloading shell; Sending SIGHUP signal to gnome-shell (equivalent to alt + f2 ; r ; enter)
+	busctl --user call org.gnome.Shell /org/gnome/Shell org.gnome.Shell Eval s 'Meta.restart("Restarting…")'
+
+	#Enabling Gnome extension.
+	gnome-extensions enable netspeedsimplified@prateekmedia.extension
+
+remove:
+	rm -rf ${EXT_HOME}
+
+	#Reloading shell; Sending SIGHUP signal to gnome-shell (equivalent to alt + f2 ; r ; enter)
+	busctl --user call org.gnome.Shell /org/gnome/Shell org.gnome.Shell Eval s 'Meta.restart("Restarting…")'
+
+remove-no-reboot:
+	rm -rf ${EXT_HOME}
+
+reinstall: remove-no-reboot install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><a href="https://extensions.gnome.org/extension/3724/net-speed-simplified/"><img src="https://user-images.githubusercontent.com/41370460/97136201-7d432980-1778-11eb-9c65-4c801a7e8e56.png" height=80px alt="NSS Logo"/></a></p>
 <h1 align="center">Net speed Simplified</h1>
-<h5 align="center"><i>Gnome extension to show network speed</i></h5> 
+<h5 align="center"><i>Gnome extension to show network speed</i></h5>
 
 [<img src="https://raw.githubusercontent.com/andyholmes/gnome-shell-extensions-badge/master/get-it-on-ego.svg?sanitize=true" height="100" alt="Get it on GNOME Extensions">](https://extensions.gnome.org/extension/3724/net-speed-simplified/) or [Install Using Terminal](#installing-the-extension-using-terminal)
 
@@ -8,14 +8,14 @@
 
 > Forked from : [biji.gnome/simplenetspeed](https://github.com/biji/simplenetspeed)
 
-<p align="center"><img src='https://raw.githubusercontent.com/prateekmedia/netspeedsimplified/main/screenshoot.png' width="500px"  alt="Screenshot"/> 
+<p align="center"><img src='https://raw.githubusercontent.com/prateekmedia/netspeedsimplified/main/screenshoot.png' width="500px"  alt="Screenshot"/>
 
 *Screenshots*
-  
+
  *Above Screenshot is with Adwaita Dark theme*</p>
 
 **Current Version** : ***20***
-   
+
 ***Tested on GNOME 3.36 and 3.38***
 
 #### Whats new in v11 and above:
@@ -24,7 +24,7 @@
 - [x] Add Position menu(with Advanced option) to pinpoint where to place the indicator on the Panel.
 - [x] Add Refresh time field by which you can change refresh time value between 1.0 sec to 10.0 sec.
 
-#### Feature Highlights : 
+#### Feature Highlights :
 - [x] Adjustable Refresh time
 - [x] Supports GNOME SHELL 3.38 and previous versions compatible
 - [x] Changes width accordingly / dynamic width
@@ -35,65 +35,87 @@
 - [x] Added space b/w speed and their units
 - [x] Human readable stylesheet // used min-width and removed repetitive codes
 - [x] Used ES6 classes for less code and more efficeint javascript
-- [x] Right Click to toggle visibility of total data used //If you will Right click on 5th mode i.e. total speed mode then total speed counter will reset to 0 MB. 
+- [x] Right Click to toggle visibility of total data used //If you will Right click on 5th mode i.e. total speed mode then total speed counter will reset to 0 MB.
 - [x] Add Preference Menu to customize the whole extension as you need
 
-#### Changelog Till v10 : 
+#### Changelog Till v10 :
 - [x] If network is not connected, then after 12 sec display text "--" for 1st mode, "----" for 2nd mode, "------" for 3rd mode, "--------" for 4th mode, for fifth mode it will display total data used(MB), Normal Right click functionality will show total data used except in 5th mode  
 - [x] Easy Vertical Alignment for Dash to panel or Big Screen users, to enable this Right Click on any mode continuously for four times to enable/disable vertical align or simply go to preferences tab for this extension.  
 *(If you have vertical align enabled then in mode 5 you will see " -v" written after total net speed)*,  
 ***Tip : You can also change font size in vertical alignment to your liking by middle mouse click on the speed***  
 - [x] Easy Switch to Old Icons from simplenetspeed extension, go to preferences tab for this extension to enable/disable old icons.  
-*(If you have old icons enabled then in mode 5 you will see " -o" written after total net speed)* 
+*(If you have old icons enabled then in mode 5 you will see " -o" written after total net speed)*
 
 if you face any **issues** you can **[open pull request](https://github.com/prateekmedia/netspeedsimplified/pulls)** and can type your issue with images or error codes
 
 > **Left click to change modes**,  
 
-  
+
 *Modes available:*
-1. Total net speed in bits per second 
+1. Total net speed in bits per second
 1. Total net speed in Bytes per second
 1. Up & down speed in bits per second
 1. Up & down speed in Bytes per second
 1. Total of downloaded in Bytes (Right click to reset counter)
-  
+
 > **Right click to toggle total data usage visibility, Right click on total data usage mode in reset counter**,  
 <p align="center"> <img src='https://user-images.githubusercontent.com/41370460/95724032-78b84480-0c93-11eb-9a2f-07976cb99e19.png' />   =====> To this   <img src='https://user-images.githubusercontent.com/41370460/95724072-8968ba80-0c93-11eb-98c9-e5651167760d.png' /></p>  
-  
+
 > **Right click continuously for 4 times in any mode to toggle vertical alignment, You will see "-v" written in 5th mode after total download data if this is enabled**  
-  
+
 > **Middle click to change font size**
 
 <h2 align="center">Installing the extension using terminal:</h2>   
 
 * Please Star this repository and mark it as Watch if you want to know about latest updates.
     - ***to install( reload required )( Requirements : git )***    
-    ```mkdir ~/.local/share/gnome-shell/extensions/; git clone --single-branch --branch main https://github.com/prateekmedia/netspeedsimplified ~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension``` 
-    
+    ```mkdir ~/.local/share/gnome-shell/extensions/; git clone --single-branch --branch main https://github.com/prateekmedia/netspeedsimplified ~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension```
+
     *Or*  
-    
+
     You can manually download the zip and paste its content in the folder  
     `~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension`  
     [Create it, if its not there]
-    
+
     - ***to load/reload extension***    
        Press ```Alt+F2``` then type ```r``` and ```hit enter```.
-       
+
     - ***to enable/disable/remove***    
       You can do that manually using extensions app or [website](https://extensions.gnome.org/local) or Using Gnome tweaks tool's extension tab  
-      
+
     - ***to reinstall or update( reload required )( Requirements : git )***   
     ```rm -rf ~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension; git clone --single-branch --branch main https://github.com/prateekmedia/netspeedsimplified ~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension```
-    
+
     *Or*  
-    
+
     First delete netspeedsimplified@prateekmedia.extension directory by typing  
     `rm -rf ~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension`
     & then
     You can manually download the latest zip and paste its content in the folder   
     `~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension`  
     [Create it, if its not there]
-    
+
     - ***to remove( using Terminal )( reload required )***   
     ```rm -rf ~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension```  
+
+# Modifcation Required
+
+## Quick install
+The extension can be quicky installed as following:
+
+    $ /bin/bash -c "$(curl -sL https://git.io/Jk28b)"
+
+
+## Installing using Make
+The Extension can be managed using Make build system as follows
+
+* Getting the sources from repository
+
+      $ git clone https://github.com/prateekmedia/netspeedsimplified.git
+
+* Running make (install)
+
+      $ make install
+
+Likewise extension can be removed (```$ make remove```) or reinstalled (```$ make reinstall```)
+

--- a/quick-install.sh
+++ b/quick-install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+set -x
+
+EXT_HOME=~/.local/share/gnome-shell/extensions/netspeedsimplified@prateekmedia.extension
+PROJECT_HOME=https://raw.githubusercontent.com/prateekmedia/netspeedsimplified/main
+
+#Create a directory structure
+mkdir -p ${EXT_HOME}
+mkdir -p ${EXT_HOME}/schemas
+
+#Copy required files
+curl ${PROJECT_HOME}/convenience.js -o ${EXT_HOME}/convenience.js
+curl ${PROJECT_HOME}/extension.js -o ${EXT_HOME}/extension.js
+curl ${PROJECT_HOME}/metadata.json -o ${EXT_HOME}/metadata.json
+curl ${PROJECT_HOME}/prefs.js -o ${EXT_HOME}/prefs.js
+curl ${PROJECT_HOME}/stylesheet.css -o ${EXT_HOME}/stylesheet.css
+curl ${PROJECT_HOME}/stylesheet.css -o ${EXT_HOME}/stylesheet.css
+curl ${PROJECT_HOME}/schemas/gschemas.compiled -o ${EXT_HOME}/schemas/gschemas.compiled
+
+#Optional files
+curl ${PROJECT_HOME}/LICENSE -o ${EXT_HOME}/LICENSE
+curl ${PROJECT_HOME}/README.md -o ${EXT_HOME}/README.md
+
+#Reloading shell; Sending SIGHUP signal to gnome-shell (equivalent to alt + f2 ; r ; enter)
+busctl --user call org.gnome.Shell /org/gnome/Shell org.gnome.Shell Eval s 'Meta.restart("Restarting…")'
+
+#Enabling Gnome extension.
+gnome-extensions enable netspeedsimplified@prateekmedia.extension


### PR DESCRIPTION
1) make build system is now incorporated into the project, which enables easy management of extension, perk: Gnome-shell is automatically reloaded, no manual restart is required. 

2) added a quick install method. I added Readme section which documents these two features and you don't need to worry about the link (https://git.io/Jk28b) because it is mapped to https://raw.githubusercontent.com/prateekmedia/netspeedsimplified/main/quick-install.sh , which is not there yet! It will appear once you merge this PR and everything makes sense. 

NOTE: DO modify the readme file. I just added sections at the end for your reference. 

Thanks & Regards.