### PR TITLE
add docker and wireguard interfaces to filter list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ If you faced an **issue** then you can **[file an issue here](https://github.com
 - [m0hithreddy](https://github.com/m0hithreddy) for his support in rewriting extension.js with Clutter and rewriting readme.md, Adopting Make build system and more..
 [Know More](https://github.com/prateekmedia/netspeedsimplified/graphs/contributors)
 
+### Troubleshooting
+
+#### VPN traffics calculated twice
+- Some VPN software creates a tun/tap interface (eg. [WireGuard](https://wireguard.com), [OpenVPN](https://openvpn.net)) and traffics are being calculated twice. Currently interfaces with these naming scheme is filtered out, make sure the interface created by your VPN software fits one of the following:
+  - `lo`: loop-back interface
+  - `ifb[0-9]+`: intermediate functional block pseudo network interface
+  - `lxdbr[0-9]+`: bridge interface created by [LXD](https://linuxcontainers.org/lxd/)
+  - `virbr[0-9]+`: bridge interface created by [LibVirt](https://libvirt.org)
+  - `docker[0-0]+`: bridge interface created by [Docker](https://docker.com)
+  - `veth[0-9a-zA-Z]+`: virtual network interface created by [Docker](https://docker.com)
+  - `br[0-9]+`: bridge interface
+  - `vnet[0-9]+`: virtual network interface
+  - `tun[0-9]+`: TUN (l3 tunnel) interface
+  - `tap[0-9]+`: TAP (l2 tunnel) interface
+  - `wg[0-9]+`: tunnel interface created by [WireGuard](https://wireguard.com)
+
 <h2 align="center">Installing Manually</h2>
   
 ### Quick install

--- a/extension.js
+++ b/extension.js
@@ -332,6 +332,7 @@ function parseStat() {
                 !fields[0].match(/^docker[0-9]+/) &&
                 !fields[0].match(/^tun[0-9]+/) &&
                 !fields[0].match(/^tap[0-9]+/) &&
+                !fields[0].match(/^wg[0-9]+/) &&
                 !isNaN(parseInt(fields[1]))) {
                 count = count + parseInt(fields[1]) + parseInt(fields[9]);
                 countUp = countUp + parseInt(fields[9]);

--- a/extension.js
+++ b/extension.js
@@ -328,6 +328,8 @@ function parseStat() {
                 !fields[0].match(/^virbr[0-9]+/) &&
                 !fields[0].match(/^br[0-9]+/) &&
                 !fields[0].match(/^vnet[0-9]+/) &&
+                !fields[0].match(/^veth[0-9a-zA-Z]+/) &&
+                !fields[0].match(/^docker[0-9]+/) &&
                 !fields[0].match(/^tun[0-9]+/) &&
                 !fields[0].match(/^tap[0-9]+/) &&
                 !isNaN(parseInt(fields[1]))) {


### PR DESCRIPTION
filter out devices:
 - `docker[0-9]+`: docker bridge interfaces
 - `veth[0-9a-zA-Z]+`: docker veth interfaces
 - `wg[0-9]+`: wireguard interfaces