### PR TITLE
Changed the text of "Show Total Download speed" toggle.

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -330,7 +330,7 @@ Prefs.prototype = {
 
         //For Default sigma View
         let hboxToggleBool = newGtkBox()
-        new NssToggleBtn(hboxToggleBool, "Show Total Download speed", "togglebool", "Enabling it will show sigma by default")
+        new NssToggleBtn(hboxToggleBool, "Show Total Data Transfer", "togglebool", "Enabling it will always show the sigma")
 
         //For Toggling Old Icons
         let hboxIconset = newGtkBox()


### PR DESCRIPTION
Changed "Show Total Download speed" toggle text to "Show Total Data Transfer". This could be a better name since the sigma does not represent any kind of speed and it includes both total download and upload.