### PR TITLE
fix: remove unwanted files from quick-install.sh

### DIFF
--- a/quick-install.sh
+++ b/quick-install.sh
@@ -13,7 +13,6 @@ mkdir -p ${EXT_HOME}
 mkdir -p ${EXT_HOME}/schemas
 
 #Copy required files
-curl ${PROJECT_HOME}/convenience.js -o ${EXT_HOME}/convenience.js
 curl ${PROJECT_HOME}/extension.js -o ${EXT_HOME}/extension.js
 curl ${PROJECT_HOME}/metadata.json -o ${EXT_HOME}/metadata.json
 curl ${PROJECT_HOME}/prefs.js -o ${EXT_HOME}/prefs.js


### PR DESCRIPTION
Remove a non-existing file
Similar to a previous commit: https://github.com/prateekmedia/netspeedsimplified/commit/6fc80b79df2162ec160c53d94d559c3c0bd03652