### PR TITLE
Add data persistence across system reboots

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -31,7 +31,8 @@ function fetchSettings() {
         uscolor: settings.get_string('uscolor'),
         dscolor: settings.get_string('dscolor'),
         tscolor: settings.get_string('tscolor'),
-        tdcolor: settings.get_string('tdcolor')
+        tdcolor: settings.get_string('tdcolor'),
+        persistdata: settings.get_boolean('persistdata')
     }
 }
 
@@ -182,7 +183,7 @@ class NssColorBtn {
         let rgba = new Gdk.RGBA()
         rgba.parse(currentSettings[name])
 
-        //Create ColorButton 
+        //Create ColorButton
         let colorButton = new Gtk.ColorButton({
             tooltip_text: tootext
         })
@@ -268,7 +269,7 @@ export default class NetSpeedSimplifiedPreferences extends ExtensionPreferences 
             let strArray = ["customfont", "uscolor", "dscolor", "tscolor", "tdcolor"]
             let intArray = ["wpos", "wposext", "mode", "fontmode", "chooseiconset", "textalign"]
             let doubleArray = ["refreshtime", "minwidth"]
-            let boolArray = ["isvertical", "togglebool", "reverseindicators", "lockmouseactions", "hideindicator", "shortenunits", "iconstoright"]
+            let boolArray = ["isvertical", "togglebool", "reverseindicators", "lockmouseactions", "hideindicator", "shortenunits", "iconstoright", "persistdata"]
             for (const i in strArray) {
                 settings.set_string(strArray[i], settings.get_default_value(strArray[i]).unpack())
             }
@@ -358,21 +359,24 @@ export default class NetSpeedSimplifiedPreferences extends ExtensionPreferences 
         let hboxSysColr = newGtkBox()
         new NssToggleBtn(hboxSysColr, "Use System Color Scheme", "systemcolr", "Enabling it will allow changing font color dynamically based on panel color")
 
-        // Upload Speed Color 
+        // Upload Speed Color
         let usColorButton = newGtkBox()
         new NssColorBtn(usColorButton, "Upload Speed Color", "uscolor", "Select the upload speed color")
 
-        // Download Speed Color 
+        // Download Speed Color
         let dsColorButton = newGtkBox()
         new NssColorBtn(dsColorButton, "Download Speed Color", "dscolor", "Select the download speed color")
 
-        // Total Speed Color 
+        // Total Speed Color
         let tsColorButton = newGtkBox()
         new NssColorBtn(tsColorButton, "Total Speed Color", "tscolor", "Select the total speed color")
 
-        // Total Download Color 
+        // Total Download Color
         let tdColorButton = newGtkBox()
         new NssColorBtn(tdColorButton, "Total Download Color", "tdcolor", "Select the total download color")
+
+        let hboxPersistData = newGtkBox()
+        new NssToggleBtn(hboxPersistData, "Remember Data Count After Reboot", "persistdata", "Enable to save data usage between reboots")
 
         addIt(vbox, resetBtn)
         frame.child = vbox

--- a/schemas/org.gnome.shell.extensions.netspeedsimplified.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.netspeedsimplified.gschema.xml
@@ -78,5 +78,10 @@
       <key name="tscolor" type="s">
         <default>"rgba(255, 255, 255, 1)"</default>
       </key>
+      <key name="persistdata" type="b">
+    	  <default>true</default>
+    	  <summary>Persist data between reboots</summary>
+    	  <description>If enabled, the extension will save data usage between system reboots</description>
+      </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
This pull request implements persistent network usage tracking, allowing the extension to remember total data usage between system reboots.

**Problem**
Previously, the extension would reset the data counter to zero after each reboot because Linux resets system network counters. This made it impossible to track total data usage over extended periods.

**Solution**
- Store counter state in a JSON file in the user's home directory (~/.netspeed_data)
- Implement a robust mechanism to detect system counter resets
- Add an offset value that persists between sessions
- Save counter state periodically and during extension disable
- Clean up code and improve error handling

**User Experience**
Users can now see their continuously accumulated network usage in Mode 5, even after rebooting their system. The counter will maintain its value between sessions, making it useful for tracking total bandwidth consumption over time.

**Testing**
Tested across multiple system reboots with various network activity patterns. The counter correctly maintains its value and continues counting from where it left off.