### PR TITLE
metadata: Add GNOME Shell 49 Suport.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "45",
     "46",
     "47",
-    "48"
+    "48",
+    "49"
   ],
   "url": "https://github.com/prateekmedia/netspeedsimplified",
   "uuid": "netspeedsimplified@prateekmedia.extension",


### PR DESCRIPTION
- Adds "49" to the shell-version array.
- Tested locally with `make install`; extension loads without errors. Had to restart gnome shell to load extension.
- Closes #83